### PR TITLE
fixed issue where __call method sometimes returned an \money\money ob…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /vendor/
 /.idea/
 /.phpunit.cache
+/.ddev/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fixed issue where `__call()` method sometimes returned an object with class \Money\Money instead of CakeDC\Money\.
+
 ## [0.0.1] - 2021-06-18
 
 * Initial version

--- a/src/Money.php
+++ b/src/Money.php
@@ -51,7 +51,12 @@ class Money
     {
         $arguments = self::processArguments($arguments);
 
-        return call_user_func_array([$this->_money, $name], $arguments);
+        $result = call_user_func_array([$this->_money, $name], $arguments);
+        if ($result instanceof MoneyPHP) {
+            return new self($result);
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Fixed issue where `__call()` method sometimes returned an object with class `\Money\Money` instead of `\CakeDC\Money`