### PR TITLE
Fix a ImplicitToStringCast of string currency

### DIFF
--- a/src/Utility/MoneyUtil.php
+++ b/src/Utility/MoneyUtil.php
@@ -116,7 +116,7 @@ class MoneyUtil
             throw new RuntimeException(
                 sprintf(
                     'Cannot format currency \'%s\'. Only ISO currencies and Bitcoin are allowed.',
-                    $currency
+                    (string) $currency
                 )
             );
         }


### PR DESCRIPTION
Fix the PSALM error validation 

`ERROR: ImplicitToStringCast - src/Utility/MoneyUtil.php:119:21 - Argument 2 of sprintf expects float|int|string, but Money\Currency provided with a __toString method (see https://psalm.dev/060)`

With a direct string cast of the variable $currency