### PR TITLE
Fix issue with float values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         if: matrix.db-type == 'pgsql'
         run: docker run --rm --name=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=cakephp -p 5432:5432 -d postgres
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m')"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
@@ -73,14 +73,14 @@ jobs:
 
       - name: Submit code coverage
         if: matrix.php-version == '8.1'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
 
   cs-stan:
     name: Coding Standard & Static Analysis
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -99,7 +99,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m')"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] 2024-03-29
+* Fixed issue with `multiply`, `divide` and `mod` first parameter, that changed the type from `string` to `int|string` breaking functionality with float values.
+
 ## [2.0.3] 2024-03-29
  * Improved the load of the FormHelper in the MoneyHelper
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -280,6 +280,8 @@ class Money
     public function __call(string $name, array $arguments): mixed
     {
         $arguments = self::processArguments($arguments);
+        $arguments = self::processFloats($name, $arguments);
+
         // @phpstan-ignore-next-line
         $result = call_user_func_array([$this->_money, $name], $arguments);
         if ($result instanceof MoneyPHP) {
@@ -320,6 +322,28 @@ class Money
         for ($i = 0; $i < $count; $i++) {
             if ($arguments[$i] instanceof Money) {
                 $arguments[$i] = $arguments[$i]->getMoney();
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Make multiply, divide and mod backward compatible with float values
+     *
+     * In v4.0.1, the first parameter from these functions changed from `string` to `int|string`,
+     * making float values lose the decimals due to auto typecast to int
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return array
+     */
+    protected static function processFloats(string $name, array $arguments = []): array
+    {
+        $functions = ['multiply', 'divide', 'mod'];
+        if (in_array($name, $functions)) {
+            if (isset($arguments[0]) && is_float($arguments[0])) {
+                $arguments[0] = (string)$arguments[0];
             }
         }
 


### PR DESCRIPTION
Make multiply, divide and mod backward compatible with float values

In v4.0.1, the first parameter from these functions changed from `string` to `int|string`,
making float values lose the decimals due to auto typecast to int.

https://github.com/moneyphp/money/blob/v4.0.0/src/Money.php#L240
https://github.com/moneyphp/money/blob/v4.0.1/src/Money.php#L241
